### PR TITLE
Add getSessionMetadata for O(1) session lookup by ID

### DIFF
--- a/src/main/java/com/github/copilot/sdk/CopilotClient.java
+++ b/src/main/java/com/github/copilot/sdk/CopilotClient.java
@@ -22,6 +22,7 @@ import com.github.copilot.sdk.json.CreateSessionResponse;
 import com.github.copilot.sdk.json.DeleteSessionResponse;
 import com.github.copilot.sdk.json.GetAuthStatusResponse;
 import com.github.copilot.sdk.json.GetLastSessionIdResponse;
+import com.github.copilot.sdk.json.GetSessionMetadataResponse;
 import com.github.copilot.sdk.json.GetModelsResponse;
 import com.github.copilot.sdk.json.GetStatusResponse;
 import com.github.copilot.sdk.json.ListSessionsResponse;
@@ -626,6 +627,34 @@ public final class CopilotClient implements AutoCloseable {
             return connection.rpc.invoke("session.list", params, ListSessionsResponse.class)
                     .thenApply(ListSessionsResponse::sessions);
         });
+    }
+
+    /**
+     * Gets metadata for a specific session by ID.
+     * <p>
+     * This provides an efficient O(1) lookup of a single session's metadata instead
+     * of listing all sessions. Returns {@code null} if the session is not found.
+     *
+     * <h2>Example Usage</h2>
+     *
+     * <pre>{@code
+     * SessionMetadata metadata = client.getSessionMetadata("session-123").get();
+     * if (metadata != null) {
+     * 	System.out.println("Session started at: " + metadata.getStartTime());
+     * }
+     * }</pre>
+     *
+     * @param sessionId
+     *            the ID of the session to look up
+     * @return a future that resolves with the session metadata, or {@code null} if
+     *         not found
+     * @see SessionMetadata
+     * @see #listSessions()
+     */
+    public CompletableFuture<SessionMetadata> getSessionMetadata(String sessionId) {
+        return ensureConnected().thenCompose(connection -> connection.rpc
+                .invoke("session.getMetadata", Map.of("sessionId", sessionId), GetSessionMetadataResponse.class)
+                .thenApply(GetSessionMetadataResponse::session));
     }
 
     /**

--- a/src/main/java/com/github/copilot/sdk/json/GetSessionMetadataResponse.java
+++ b/src/main/java/com/github/copilot/sdk/json/GetSessionMetadataResponse.java
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+package com.github.copilot.sdk.json;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Internal response object from getting session metadata.
+ * <p>
+ * This is a low-level class for JSON-RPC communication containing the metadata
+ * for a specific session, or {@code null} if the session was not found.
+ *
+ * @see com.github.copilot.sdk.CopilotClient#getSessionMetadata(String)
+ * @see SessionMetadata
+ * @since 1.0.0
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record GetSessionMetadataResponse(
+        /** The session metadata, or {@code null} if the session was not found. */
+        @JsonProperty("session") SessionMetadata session) {
+}

--- a/src/main/java/com/github/copilot/sdk/json/GetSessionMetadataResponse.java
+++ b/src/main/java/com/github/copilot/sdk/json/GetSessionMetadataResponse.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  * @see com.github.copilot.sdk.CopilotClient#getSessionMetadata(String)
  * @see SessionMetadata
- * @since 1.0.0
+ * @since 1.2.0
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record GetSessionMetadataResponse(

--- a/src/main/java/com/github/copilot/sdk/json/SessionMetadata.java
+++ b/src/main/java/com/github/copilot/sdk/json/SessionMetadata.java
@@ -11,7 +11,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Metadata about an existing Copilot session.
  * <p>
  * This class represents session information returned when listing available
- * sessions via {@link com.github.copilot.sdk.CopilotClient#listSessions()}. It
+ * sessions via {@link com.github.copilot.sdk.CopilotClient#listSessions()} or
+ * looking up a specific session via
+ * {@link com.github.copilot.sdk.CopilotClient#getSessionMetadata(String)}. It
  * includes timing information, a summary of the conversation, and whether the
  * session is stored remotely.
  *

--- a/src/main/java/com/github/copilot/sdk/json/SessionMetadata.java
+++ b/src/main/java/com/github/copilot/sdk/json/SessionMetadata.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * }</pre>
  *
  * @see com.github.copilot.sdk.CopilotClient#listSessions()
+ * @see com.github.copilot.sdk.CopilotClient#getSessionMetadata(String)
  * @see com.github.copilot.sdk.CopilotClient#resumeSession(String,
  *      ResumeSessionConfig)
  * @since 1.0.0

--- a/src/test/java/com/github/copilot/sdk/CopilotSessionTest.java
+++ b/src/test/java/com/github/copilot/sdk/CopilotSessionTest.java
@@ -698,12 +698,12 @@ public class CopilotSessionTest {
     /**
      * Verifies that session metadata can be retrieved by ID.
      * <p>
-     * TODO: Re-enable once test harness CAPI proxy supports this test's session
-     * lifecycle.
+     * Disabled until {@code .lastmerge} is advanced past upstream PR #899 which
+     * adds the {@code should_get_session_metadata} snapshot.
      *
      * @see Snapshot: session/should_get_session_metadata
      */
-    @Disabled("Needs test harness CAPI proxy support")
+    @Disabled("Snapshot not available until .lastmerge is advanced past upstream PR #899")
     @Test
     void testShouldGetSessionMetadata() throws Exception {
         ctx.configureForTest("session", "should_get_session_metadata");

--- a/src/test/java/com/github/copilot/sdk/CopilotSessionTest.java
+++ b/src/test/java/com/github/copilot/sdk/CopilotSessionTest.java
@@ -7,6 +7,7 @@ package com.github.copilot.sdk;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -19,6 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.github.copilot.sdk.events.AbstractSessionEvent;
@@ -690,6 +692,48 @@ public class CopilotSessionTest {
                 // Should throw an error indicating session not found
                 assertTrue(e.getMessage() != null || e.getCause() != null, "Exception should have a message or cause");
             }
+        }
+    }
+
+    /**
+     * Verifies that session metadata can be retrieved by ID.
+     * <p>
+     * TODO: Re-enable once test harness CAPI proxy supports this test's session
+     * lifecycle.
+     *
+     * @see Snapshot: session/should_get_session_metadata
+     */
+    @Disabled("Needs test harness CAPI proxy support")
+    @Test
+    void testShouldGetSessionMetadata() throws Exception {
+        ctx.configureForTest("session", "should_get_session_metadata");
+
+        try (CopilotClient client = ctx.createClient()) {
+            CopilotSession session = client
+                    .createSession(new SessionConfig().setOnPermissionRequest(PermissionHandler.APPROVE_ALL)).get();
+
+            session.sendAndWait(new MessageOptions().setPrompt("Say hello")).get(60, TimeUnit.SECONDS);
+
+            // Small delay to ensure session file is written to disk
+            Thread.sleep(200);
+
+            // Get metadata for the session we just created
+            var metadata = client.getSessionMetadata(session.getSessionId()).get(30, TimeUnit.SECONDS);
+            assertNotNull(metadata);
+            assertEquals(session.getSessionId(), metadata.getSessionId());
+            assertNotNull(metadata.getStartTime());
+            assertNotNull(metadata.getModifiedTime());
+
+            // Verify context field
+            if (metadata.getContext() != null) {
+                assertNotNull(metadata.getContext().getCwd());
+            }
+
+            // Verify non-existent session returns null
+            var notFound = client.getSessionMetadata("non-existent-session-id").get(30, TimeUnit.SECONDS);
+            assertNull(notFound);
+
+            session.close();
         }
     }
 


### PR DESCRIPTION
Ports upstream <a href="https://github.com/github/copilot-sdk/pull/899">copilot-sdk PR #899</a> to the Java SDK. Adds a new `getSessionMetadata(String sessionId)` method to `CopilotClient` that calls the `session.getMetadata` JSON-RPC endpoint for efficient O(1) single-session metadata lookup. Returns `null` when the session is not found (Java-idiomatic absent value).

----

### Before the change?

* No way to look up a single session's metadata by ID — callers had to use `listSessions()` and filter client-side.

### After the change?

* **`CopilotClient.java`** — New `getSessionMetadata(String)` method following the same pattern as `listSessions`/`deleteSession`
* **`GetSessionMetadataResponse.java`** — New response DTO record (`@since 1.2.0`) for the `session.getMetadata` RPC call
* **`SessionMetadata.java`** — Updated Javadoc with `@see` tag referencing the new method
* **`CopilotSessionTest.java`** — New `@Disabled` E2E test; disabled because the `should_get_session_metadata` snapshot was added by upstream PR #899 and won't be available until `.lastmerge` is advanced past that PR

#### Upstream reference

| SDK | Method | Return type | Not-found value |
|-----|--------|-------------|-----------------|
| **Java** | `getSessionMetadata(sessionId)` | `CompletableFuture<SessionMetadata>` | `null` |

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] `mvn spotless:apply` has been run to format the code
- [x] `mvn clean verify` passes locally

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

----

<!-- START COPILOT CODING AGENT TIPS -->
---

🔒 GitHub Advanced Security automatically protects Copilot coding agent pull requests. You can protect all pull requests by enabling Advanced Security for your repositories. [Learn more about Advanced Security.](https://gh.io/cca-advanced-security)