### PR TITLE
On branch edburns/dd-2855288-add-smoke-test-to-build-and-test Make it so the branch protection rules are respected regarding pushing the badge update to `main`

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,9 +19,7 @@ on:
   merge_group:
 
 permissions:
-  contents: write
-  checks: write
-  pull-requests: write
+  contents: read
 
 jobs:
 
@@ -35,6 +33,10 @@ jobs:
     name: "Java SDK Tests"
     needs: smoke-test
     if: ${{ always() && needs.smoke-test.result != 'failure' }}
+    permissions:
+      contents: write
+      checks: write
+      pull-requests: write
 
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION

modified:   .github/workflows/build-test.yml

Fixes #31