### PR TITLE
Fix stale snapshot version in README and automate updates

### DIFF
--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -121,6 +121,10 @@ jobs:
                   sed -i "s|<version>[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\(-java\.[0-9][0-9]*\)\{0,1\}</version>|<version>${VERSION}</version>|g" README.md
                   sed -i "s|copilot-sdk-java:[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\(-java\.[0-9][0-9]*\)\{0,1\}|copilot-sdk-java:${VERSION}|g" README.md
                   
+                  # Update snapshot version in README.md
+                  DEV_VERSION="${{ steps.versions.outputs.dev_version }}"
+                  sed -i "s|<version>[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\(-java\.[0-9][0-9]*\)\{0,1\}-SNAPSHOT</version>|<version>${DEV_VERSION}</version>|g" README.md
+                  
                   # Update version in jbang-example.java
                   sed -i "s|copilot-sdk-java:[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\(-java\.[0-9][0-9]*\)\{0,1\}|copilot-sdk-java:${VERSION}|g" jbang-example.java
                   

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Snapshot builds of the next development version are published to Maven Central S
 <dependency>
     <groupId>com.github</groupId>
     <artifactId>copilot-sdk-java</artifactId>
-    <version>0.2.1-java.0-SNAPSHOT</version>
+    <version>0.2.3-java.1-SNAPSHOT</version>
 </dependency>
 ```
 


### PR DESCRIPTION
### Problem
The snapshot version in README.md was stuck at `0.2.1-java.0-SNAPSHOT` while the current pom.xml is at `0.2.3-java.1-SNAPSHOT`. The release workflow's sed patterns only matched non-SNAPSHOT `<version>` tags, so the snapshot line was never updated during releases.

### Changes
- **README.md**: Fix snapshot version from `0.2.1-java.0-SNAPSHOT` → `0.2.3-java.1-SNAPSHOT`
- **publish-maven.yml**: Add a sed command to update the `-SNAPSHOT` version in README during releases using `DEV_VERSION` from the versions step, preventing this from going stale again