### PR TITLE
Fix jbang-example.java to use actual version instead of Maven placeholder

### DIFF
--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -123,6 +123,7 @@ jobs:
                   
                   # Update version in jbang-example.java
                   sed -i "s|copilot-sdk-java:[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\(-java\.[0-9][0-9]*\)\{0,1\}|copilot-sdk-java:${VERSION}|g" jbang-example.java
+                  sed -i "s|copilot-sdk-java:\${project\.version}|copilot-sdk-java:${VERSION}|g" jbang-example.java
                   
                   # Update version in cookbook files (hardcoded for direct GitHub browsing and JBang usage)
                   find src/site/markdown/cookbook -name "*.md" -type f -exec \

--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -123,7 +123,7 @@ jobs:
                   
                   # Update version in jbang-example.java
                   sed -i "s|copilot-sdk-java:[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\(-java\.[0-9][0-9]*\)\{0,1\}|copilot-sdk-java:${VERSION}|g" jbang-example.java
-                  sed -i "s|copilot-sdk-java:\${project\.version}|copilot-sdk-java:${VERSION}|g" jbang-example.java
+                  sed -i 's|copilot-sdk-java:${project\.version}|copilot-sdk-java:'"${VERSION}"'|g' jbang-example.java
                   
                   # Update version in cookbook files (hardcoded for direct GitHub browsing and JBang usage)
                   find src/site/markdown/cookbook -name "*.md" -type f -exec \

--- a/jbang-example.java
+++ b/jbang-example.java
@@ -1,5 +1,5 @@
 !
-//DEPS com.github:copilot-sdk-java:${project.version}
+//DEPS com.github:copilot-sdk-java:0.2.2-java.1
 import com.github.copilot.sdk.CopilotClient;
 import com.github.copilot.sdk.events.AssistantMessageEvent;
 import com.github.copilot.sdk.events.SessionUsageInfoEvent;


### PR DESCRIPTION
## Summary

Replace `${project.version}` with a real version number in `jbang-example.java`. The Maven placeholder was never resolved for this file since it's not processed by Maven's resource filtering (it lives at the repo root, not under `src/site/markdown/`).

## Changes

- **`jbang-example.java`**: Replaced `${project.version}` with `0.2.2-java.1` (latest release)
- **`.github/workflows/publish-maven.yml`**: Added a fallback `sed` pattern to match and replace the `${project.version}` literal during the transition, so future releases will correctly update the version

## Testing

- Ran `DocumentationSamplesTest` — passes successfully