### PR TITLE
Configure Dependabot to monitor @github/copilot npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,15 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/scripts/codegen"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 1
+    allow:
+      - dependency-name: "@github/copilot"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"
 


### PR DESCRIPTION
- Add npm ecosystem entry for scripts/codegen/ directory
- Filter to @github/copilot package only (daily schedule)
- Add github-actions ecosystem entry for workflow updates (weekly)


Related to #93 .
----

### Before the change?

* There is no agentic way to keep the generated code in sync with the reference implementation.

### After the change?

* This way exists.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] `mvn spotless:apply` has been run to format the code
- [ ] `mvn clean verify` passes locally

### Does this introduce a breaking change?

- [ ] Yes
- [X] No infrastructure only.

----
