### PR TITLE
Exclude gh-aw managed actions from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # gh-aw generated files — action SHAs are managed by `gh aw compile`
+      # via .github/aw/actions-lock.json, not by Dependabot.
+      # Dependabot's find-and-replace breaks lockfile metadata headers.
+      - dependency-name: "actions/github-script"
+      - dependency-name: "github/gh-aw-actions/*"
 
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Dependabot's mechanical SHA find-and-replace in workflow files breaks gh-aw lockfile metadata headers, causing runtime validation failures. The affected actions (`actions/github-script`, `github/gh-aw-actions/*`) are only used in gh-aw generated files and their SHAs are managed via `.github/aw/actions-lock.json` + `gh aw compile`.

Added `ignore` rules to `.github/dependabot.yml` for these dependencies.

Add maven ecosystem.
