### PR TITLE
edburns/dd-2969317-dependabot-gh-aw-exclude

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
       # via .github/aw/actions-lock.json, not by Dependabot.
       # Dependabot's find-and-replace breaks lockfile metadata headers.
       - dependency-name: "actions/github-script"
-      - dependency-name: "github/gh-aw-actions/*"
+      - dependency-name: "github/gh-aw-actions"
 
   - package-ecosystem: "maven"
     directory: "/"


### PR DESCRIPTION
modified:   .github/dependabot.yml

Match against inputs as appropriate for the intent: make it so dependabot doesn't change things that should only be changed by running `gh aw compile`.

