### PR TITLE
Fix jbang-example.java shebang line and dependency version

### DIFF
--- a/jbang-example.java
+++ b/jbang-example.java
@@ -1,5 +1,5 @@
-!
-//DEPS com.github:copilot-sdk-java:0.3.0-java.2
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS com.github:copilot-sdk-java:0.3.1-java.1-SNAPSHOT
 import com.github.copilot.sdk.CopilotClient;
 import com.github.copilot.sdk.generated.AssistantMessageEvent;
 import com.github.copilot.sdk.generated.SessionUsageInfoEvent;


### PR DESCRIPTION
## Summary

Fixes `jbang-example.java` so it can be run with `jbang`.

## Changes

- **Dependency version**: Updated `//DEPS` from `0.3.0-java.2` to current `0.3.1-java.1-SNAPSHOT`

## Testing

Ran `jbang jbang-example.java` locally — Copilot connected successfully and answered a test prompt.