### PR TITLE
Edburns/dd 2984436 make copilot cli versions consistent

### DIFF
--- a/.github/actions/setup-copilot/action.yml
+++ b/.github/actions/setup-copilot/action.yml
@@ -10,7 +10,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v6
       with:
         node-version: 22
     - name: Read pinned @github/copilot version from pom.xml

--- a/.github/actions/setup-copilot/action.yml
+++ b/.github/actions/setup-copilot/action.yml
@@ -4,15 +4,36 @@ outputs:
   cli-path:
     description: "Path to the Copilot CLI executable"
     value: ${{ steps.cli-path.outputs.path }}
+  cli-version:
+    description: "Pinned @github/copilot version installed (read from pom.xml)"
+    value: ${{ steps.cli-version.outputs.version }}
 runs:
   using: "composite"
   steps:
     - uses: actions/setup-node@v6
       with:
         node-version: 22
-    - name: Install Copilot CLI
-      run: npm install -g @github/copilot
+    - name: Read pinned @github/copilot version from pom.xml
+      id: cli-version
       shell: bash
+      # The version is the SINGLE SOURCE OF TRUTH for the Copilot CLI version
+      # used across all CI paths. It is kept in sync with the reference
+      # implementation pinned in .lastmerge by
+      # .github/scripts/reference-impl-sync/sync-cli-version-from-reference-impl.sh.
+      run: |
+        PROP="readonly-copilot-sdk-ref-impl-version-from-lastmerge-file-updated-by-weekly-reference-impl-sync"
+        VERSION=$(sed -n "s|.*<${PROP}>\(.*\)</${PROP}>.*|\1|p" pom.xml | head -n 1 | tr -d '[:space:]')
+        if [[ -z "$VERSION" || "$VERSION" == "PRIMER_TO_REPLACE" ]]; then
+          echo "::error::Could not read pinned @github/copilot version from pom.xml property <${PROP}>" >&2
+          exit 1
+        fi
+        echo "Pinned @github/copilot version: $VERSION"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+    - name: Install Copilot CLI (pinned to pom.xml version)
+      shell: bash
+      env:
+        CLI_VERSION: ${{ steps.cli-version.outputs.version }}
+      run: npm install -g "@github/copilot@${CLI_VERSION}"
     - name: Set CLI path
       id: cli-path
       run: echo "path=$(which copilot)" >> $GITHUB_OUTPUT

--- a/.github/scripts/reference-impl-sync/merge-reference-impl-finish.sh
+++ b/.github/scripts/reference-impl-sync/merge-reference-impl-finish.sh
@@ -57,7 +57,7 @@ echo "▸ Syncing @github/copilot version in pom.xml from reference implementati
 "$ROOT_DIR/.github/scripts/reference-impl-sync/sync-cli-version-from-reference-impl.sh" "$REFERENCE_IMPL_DIR"
 
 git add .lastmerge pom.xml
-git commit -m "Update .lastmerge to $NEW_COMMIT"
+git commit -m "Update .lastmerge to $NEW_COMMIT and sync pom.xml CLI version"
 
 # ── 3. Push branch ───────────────────────────────────────────
 echo "▸ Pushing branch $BRANCH_NAME to origin…"

--- a/.github/scripts/reference-impl-sync/merge-reference-impl-finish.sh
+++ b/.github/scripts/reference-impl-sync/merge-reference-impl-finish.sh
@@ -5,8 +5,10 @@
 # Finalises a reference implementation merge:
 #   1. Runs format + test + build  (via format-and-test.sh)
 #   2. Updates .lastmerge to reference implementation HEAD
-#   3. Commits the .lastmerge update
-#   4. Pushes the branch to origin
+#   3. Syncs the @github/copilot version property in pom.xml from the
+#      cloned reference implementation's nodejs/package.json
+#   4. Commits the .lastmerge + pom.xml updates
+#   5. Pushes the branch to origin
 #
 # Usage:  ./.github/scripts/reference-impl-sync/merge-reference-impl-finish.sh
 #         ./.github/scripts/reference-impl-sync/merge-reference-impl-finish.sh --skip-tests
@@ -48,7 +50,13 @@ echo "▸ Updating .lastmerge…"
 NEW_COMMIT=$(cd "$REFERENCE_IMPL_DIR" && git rev-parse origin/main)
 echo "$NEW_COMMIT" > "$ROOT_DIR/.lastmerge"
 
-git add .lastmerge
+# ── 2b. Sync pom.xml @github/copilot version ─────────────────
+# Keeps the canonical CLI version in pom.xml aligned with what the
+# reference implementation pinned in .lastmerge depends on.
+echo "▸ Syncing @github/copilot version in pom.xml from reference implementation…"
+"$ROOT_DIR/.github/scripts/reference-impl-sync/sync-cli-version-from-reference-impl.sh" "$REFERENCE_IMPL_DIR"
+
+git add .lastmerge pom.xml
 git commit -m "Update .lastmerge to $NEW_COMMIT"
 
 # ── 3. Push branch ───────────────────────────────────────────

--- a/.github/scripts/reference-impl-sync/sync-cli-version-from-reference-impl.sh
+++ b/.github/scripts/reference-impl-sync/sync-cli-version-from-reference-impl.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# ──────────────────────────────────────────────────────────────
+# sync-cli-version-from-reference-impl.sh
+#
+# Reads the @github/copilot version specifier from the cloned
+# reference implementation's nodejs/package.json, and updates the
+# corresponding property in pom.xml:
+#
+#   <readonly-copilot-sdk-ref-impl-version-from-lastmerge-file-updated-by-weekly-reference-impl-sync>
+#
+# This keeps the canonical Copilot CLI version (declared in pom.xml)
+# in sync with whatever the reference implementation pinned in
+# .lastmerge depends on. All workflows that install the Copilot CLI
+# (build-test.yml — implicitly via cloned SDK, run-smoke-test.yml and
+# update-copilot-dependency.yml — via the setup-copilot action) read
+# this single property so every CI path uses the same CLI version.
+#
+# Usage:
+#   ./sync-cli-version-from-reference-impl.sh <reference-impl-dir>
+#
+# Or, when invoked from merge-reference-impl-finish.sh, sources
+# REFERENCE_IMPL_DIR from the .merge-env file.
+# ──────────────────────────────────────────────────────────────
+set -euo pipefail
+
+# Locate the repo root by walking up from this script until we find a pom.xml.
+# This is resilient to the script being moved to a different depth under
+# .github/scripts/ in the future.
+find_repo_root() {
+    local dir
+    dir="$(cd "$(dirname "$0")" && pwd)"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -f "$dir/pom.xml" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "❌ Could not locate repo root (no pom.xml found above $(dirname "$0"))" >&2
+    return 1
+}
+ROOT_DIR="$(find_repo_root)"
+
+REFERENCE_IMPL_DIR="${1:-${REFERENCE_IMPL_DIR:-}}"
+if [[ -z "$REFERENCE_IMPL_DIR" ]]; then
+    echo "❌ Usage: $0 <reference-impl-dir>" >&2
+    echo "   or set REFERENCE_IMPL_DIR in the environment." >&2
+    exit 1
+fi
+
+PKG_JSON="$REFERENCE_IMPL_DIR/nodejs/package.json"
+if [[ ! -f "$PKG_JSON" ]]; then
+    echo "❌ Cannot find $PKG_JSON" >&2
+    exit 1
+fi
+
+# node is always available since the reference implementation uses npm.
+CLI_VERSION=$(node -e \
+    "const fs=require('fs');const p=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const v=(p.dependencies&&p.dependencies['@github/copilot'])||(p.devDependencies&&p.devDependencies['@github/copilot']);if(!v){process.exit(2);}process.stdout.write(v);" \
+    "$PKG_JSON")
+
+if [[ -z "$CLI_VERSION" ]]; then
+    echo "❌ Could not extract @github/copilot version from $PKG_JSON" >&2
+    exit 1
+fi
+
+POM="$ROOT_DIR/pom.xml"
+PROP="readonly-copilot-sdk-ref-impl-version-from-lastmerge-file-updated-by-weekly-reference-impl-sync"
+
+if ! grep -q "<${PROP}>" "$POM"; then
+    echo "❌ Property <${PROP}> not found in $POM" >&2
+    exit 1
+fi
+
+# Use a portable sed invocation (works on both BSD/macOS and GNU/Linux).
+TMP="$(mktemp)"
+sed -E "s|<${PROP}>[^<]*</${PROP}>|<${PROP}>${CLI_VERSION}</${PROP}>|" "$POM" > "$TMP"
+mv "$TMP" "$POM"
+
+echo "▸ Updated pom.xml: <${PROP}> = ${CLI_VERSION}"

--- a/.github/scripts/reference-impl-sync/sync-cli-version-from-reference-impl.sh
+++ b/.github/scripts/reference-impl-sync/sync-cli-version-from-reference-impl.sh
@@ -56,7 +56,7 @@ fi
 
 # node is always available since the reference implementation uses npm.
 CLI_VERSION=$(node -e \
-    "const fs=require('fs');const p=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const v=(p.dependencies&&p.dependencies['@github/copilot'])||(p.devDependencies&&p.devDependencies['@github/copilot']);if(!v){process.exit(2);}process.stdout.write(v);" \
+    "const fs=require('fs');const p=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const v=(p.dependencies&&p.dependencies['@github/copilot'])||(p.devDependencies&&p.devDependencies['@github/copilot']);process.stdout.write(v||'');" \
     "$PKG_JSON")
 
 if [[ -z "$CLI_VERSION" ]]; then

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ changebundle.txt*
 .settings
 scripts/codegen/node_modules/
 *~
+*.sln

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,9 +38,41 @@ If you have ideas for entirely new features, please post an issue or start a dis
 1. Push to your fork and [submit a pull request][pr]
 1. Pat yourself on the back and wait for your pull request to be reviewed and merged.
 
-### Running tests and linters
+### Running locally, including tests and linters
 
 ```bash
+# Obtain the pinned version of Copilot CLI to the local workarea.
+# This clones the reference implementation at the commit pinned in
+# .lastmerge, but does NOT run `npm ci` inside its nodejs/ subdir.
+mvn generate-test-resources
+
+# Install the pinned Copilot CLI into target/copilot-sdk/nodejs/node_modules
+# so the SDK tests use the version declared in
+# target/copilot-sdk/nodejs/package.json (the SDK-test pin), NOT the version
+# in target/copilot-sdk/test/harness/package.json (the replay-harness pin,
+# which is incidental and may be older).
+
+## POSIX
+
+(cd target/copilot-sdk/nodejs && npm ci --ignore-scripts)
+
+## PowerShell
+
+Push-Location target\copilot-sdk\nodejs; if ($?) { npm ci --ignore-scripts }; Pop-Location
+
+# Make it so the pinned Copilot CLI is used for the tests. The patterns
+# below are scoped to the `nodejs/node_modules/` subtree so they cannot
+# accidentally pick up the older harness copy under
+# target/copilot-sdk/test/harness/node_modules/.
+
+## POSIX
+
+export COPILOT_CLI_PATH="$(find "$PWD/target" -type f -path '*/nodejs/node_modules/@github/copilot/index.js' | head -n 1)"
+
+## PowerShell
+
+$env:COPILOT_CLI_PATH = (Get-ChildItem -Path "$PWD\target" -Recurse -Filter 'index.js' -File | Where-Object { $_.FullName -match '[\\/]nodejs[\\/]node_modules[\\/]@github[\\/]copilot[\\/]index\.js$' } | Select-Object -First 1 -ExpandProperty FullName)
+
 # Build and run all tests
 mvn clean verify
 
@@ -52,6 +84,20 @@ mvn spotless:apply
 
 # Check formatting only
 mvn spotless:check
+```
+
+Assuming you are in the same shell you used to run the above commands, to run this exact Copilot CLI locally you can do the following.
+
+### POSIX
+
+```bash
+node ${COPILOT_CLI_PATH}
+```
+
+### PowerShell
+
+```PowerShell
+node $env:COPILOT_CLI_PATH
 ```
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,39 +40,9 @@ If you have ideas for entirely new features, please post an issue or start a dis
 
 ### Running locally, including tests and linters
 
+The POM has logic to ensure a known correct installation of Copilot CLI is used when executing the tests. If you want to test against a different installation of Copilot CLI, set the value of the `copilot.cli.path` maven property to the fully qualified path to the Copilot CLI.
+
 ```bash
-# Obtain the pinned version of Copilot CLI to the local workarea.
-# This clones the reference implementation at the commit pinned in
-# .lastmerge, but does NOT run `npm ci` inside its nodejs/ subdir.
-mvn generate-test-resources
-
-# Install the pinned Copilot CLI into target/copilot-sdk/nodejs/node_modules
-# so the SDK tests use the version declared in
-# target/copilot-sdk/nodejs/package.json (the SDK-test pin), NOT the version
-# in target/copilot-sdk/test/harness/package.json (the replay-harness pin,
-# which is incidental and may be older).
-
-## POSIX
-
-(cd target/copilot-sdk/nodejs && npm ci --ignore-scripts)
-
-## PowerShell
-
-Push-Location target\copilot-sdk\nodejs; if ($?) { npm ci --ignore-scripts }; Pop-Location
-
-# Make it so the pinned Copilot CLI is used for the tests. The patterns
-# below are scoped to the `nodejs/node_modules/` subtree so they cannot
-# accidentally pick up the older harness copy under
-# target/copilot-sdk/test/harness/node_modules/.
-
-## POSIX
-
-export COPILOT_CLI_PATH="$(find "$PWD/target" -type f -path '*/nodejs/node_modules/@github/copilot/index.js' | head -n 1)"
-
-## PowerShell
-
-$env:COPILOT_CLI_PATH = (Get-ChildItem -Path "$PWD\target" -Recurse -Filter 'index.js' -File | Where-Object { $_.FullName -match '[\\/]nodejs[\\/]node_modules[\\/]@github[\\/]copilot[\\/]index\.js$' } | Select-Object -First 1 -ExpandProperty FullName)
-
 # Build and run all tests
 mvn clean verify
 
@@ -86,17 +56,19 @@ mvn spotless:apply
 mvn spotless:check
 ```
 
-Assuming you are in the same shell you used to run the above commands, to run this exact Copilot CLI locally you can do the following.
+## Running the known correct Copilot CLI installation
 
 ### POSIX
 
 ```bash
+export COPILOT_CLI_PATH="$(find "$PWD/target" -type f -path '*/nodejs/node_modules/@github/copilot/index.js' | head -n 1)"
 node ${COPILOT_CLI_PATH}
 ```
 
 ### PowerShell
 
 ```PowerShell
+$env:COPILOT_CLI_PATH = (Get-ChildItem -Path "$PWD\target" -Recurse -Filter 'index.js' -File | Where-Object { $_.FullName -match '[\\/]nodejs[\\/]node_modules[\\/]@github[\\/]copilot[\\/]index\.js$' } | Select-Object -First 1 -ExpandProperty FullName)
 node $env:COPILOT_CLI_PATH
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,27 @@
         <skip.test.harness>false</skip.test.harness>
         <!-- Extra JVM args for Surefire; overridden by the jdk21+ profile -->
         <surefire.jvm.args />
+        <!--
+            The version of the @github/copilot npm package that the reference implementation
+            commit pinned in .lastmerge depends on. Mirrors the value of dependencies."@github/copilot"
+            in target/copilot-sdk/nodejs/package.json after the reference impl is cloned/reset to the
+            commit in .lastmerge.
+
+            The previously mentioned package.json contains the SINGLE
+            SOURCE OF TRUTH for the Copilot CLI version that all paths
+            (build-test.yml, run-smoke-test.yml,
+            update-copilot-dependency.yml, setup-copilot action) must
+            pin to. It is updated automatically by
+            .github/scripts/reference-impl-sync/sync-cli-version-from-reference-impl.sh,
+            which is called from merge-reference-impl-finish.sh
+            whenever .lastmerge is updated.
+
+            DO NOT EDIT MANUALLY. To update, run the
+            reference-impl-sync workflow and deal with the subsequent
+            PR.
+        -->
+        <readonly-copilot-sdk-ref-impl-version-from-lastmerge-file-updated-by-weekly-reference-impl-sync>^1.0.36-0</readonly-copilot-sdk-ref-impl-version-from-lastmerge-file-updated-by-weekly-reference-impl-sync>
+
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,17 @@
         <copilot.cli.path>${copilot.sdk.clone.dir}/nodejs/node_modules/@github/copilot/index.js</copilot.cli.path>
         <!-- Set to true (via -Pskip-test-harness) to skip git-clone + npm install of test harness -->
         <skip.test.harness>false</skip.test.harness>
+        <!--
+            Whether to skip the install-nodejs-cli-dependencies execution
+            (npm ci of the @github/copilot CLI). Defaults to ${skip.test.harness}
+            so it tracks the rest of the test-harness setup, but is also
+            forced to true when Maven tests are skipped (-DskipTests or
+            -Dmaven.test.skip) via the skip-cli-install-when-tests-skipped
+            and skip-cli-install-when-maven-test-skip profiles below, so that
+            non-test builds (e.g. package/deploy with tests skipped) do not
+            require npm or network access.
+        -->
+        <skip.cli.install>${skip.test.harness}</skip.cli.install>
         <!-- Extra JVM args for Surefire; overridden by the jdk21+ profile -->
         <surefire.jvm.args />
         <!--
@@ -292,7 +303,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <skip>${skip.test.harness}</skip>
+                            <skip>${skip.cli.install}</skip>
                             <executable>npm</executable>
                             <workingDirectory>${copilot.sdk.clone.dir}/nodejs</workingDirectory>
                             <arguments>
@@ -655,6 +666,39 @@
             <id>skip-test-harness</id>
             <properties>
                 <skip.test.harness>true</skip.test.harness>
+            </properties>
+        </profile>
+        <!--
+            Skip the install-nodejs-cli-dependencies (npm ci) execution when
+            tests are skipped via -DskipTests, so non-test builds do not
+            require npm or network access. Activates automatically; no manual
+            -P needed.
+        -->
+        <profile>
+            <id>skip-cli-install-when-tests-skipped</id>
+            <activation>
+                <property>
+                    <name>skipTests</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <skip.cli.install>true</skip.cli.install>
+            </properties>
+        </profile>
+        <!--
+            Same as above, but for -Dmaven.test.skip=true.
+        -->
+        <profile>
+            <id>skip-cli-install-when-maven-test-skip</id>
+            <activation>
+                <property>
+                    <name>maven.test.skip</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <skip.cli.install>true</skip.cli.install>
             </properties>
         </profile>
         <!-- Debug profile for FINE logging during tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,17 @@
         <!-- Directory where the copilot-sdk repo will be cloned for tests -->
         <copilot.sdk.clone.dir>${project.build.directory}/copilot-sdk</copilot.sdk.clone.dir>
         <copilot.tests.dir>${copilot.sdk.clone.dir}/test</copilot.tests.dir>
+        <!--
+            Path to the Copilot CLI entry point used by the SDK tests. Defaults
+            to the CLI installed under target/copilot-sdk/nodejs by the
+            install-nodejs-cli-dependencies execution. Surefire injects this
+            into the test JVM as the COPILOT_CLI_PATH environment variable, so
+            `mvn verify` is self-contained and the developer never has to set
+            it manually. Override on the command line to point at a different
+            CLI build, e.g.:
+              mvn verify -Dcopilot.cli.path=/some/other/copilot/index.js
+        -->
+        <copilot.cli.path>${copilot.sdk.clone.dir}/nodejs/node_modules/@github/copilot/index.js</copilot.cli.path>
         <!-- Set to true (via -Pskip-test-harness) to skip git-clone + npm install of test harness -->
         <skip.test.harness>false</skip.test.harness>
         <!-- Extra JVM args for Surefire; overridden by the jdk21+ profile -->
@@ -261,6 +272,35 @@
                             </arguments>
                         </configuration>
                     </execution>
+                    <!--
+                        Install the @github/copilot CLI declared by
+                        target/copilot-sdk/nodejs/package.json. This is the CLI
+                        version the SDK tests must run against (independent of
+                        the older pin in test/harness/package.json which is
+                        incidental to harness internals). Mirrors what
+                        .github/workflows/build-test.yml does manually so that
+                        `mvn clean verify` is self-contained: the prior
+                        target/copilot-sdk/nodejs/node_modules is wiped by
+                        clean, but this re-creates it before tests run.
+                        Uses npm ci with the ignore-scripts flag, matching
+                        build-test.yml.
+                    -->
+                    <execution>
+                        <id>install-nodejs-cli-dependencies</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skip.test.harness}</skip>
+                            <executable>npm</executable>
+                            <workingDirectory>${copilot.sdk.clone.dir}/nodejs</workingDirectory>
+                            <arguments>
+                                <argument>ci</argument>
+                                <argument>--ignore-scripts</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -274,6 +314,15 @@
                         <copilot.tests.dir>${copilot.tests.dir}</copilot.tests.dir>
                         <copilot.sdk.dir>${copilot.sdk.clone.dir}</copilot.sdk.dir>
                     </systemPropertyVariables>
+                    <!--
+                        Set COPILOT_CLI_PATH for the forked test JVM so the SDK
+                        tests transparently use the pinned CLI under
+                        target/copilot-sdk/nodejs/. See the copilot.cli.path
+                        property above for the override mechanism.
+                    -->
+                    <environmentVariables>
+                        <COPILOT_CLI_PATH>${copilot.cli.path}</COPILOT_CLI_PATH>
+                    </environmentVariables>
                 </configuration>
             </plugin>
             <!-- Add src/generated/java as an additional source root -->


### PR DESCRIPTION
This PR makes it so all the places that need to invoke Copilot CLI in the process of running tests or dealing with agentic workflows, use the same Copilot CLI installation, and therefore Copilot CLI version, as defined in the `@github/copilot` corresponding to the commit has in `.lastmerge`. This version number is also written to the POM as the value of the property `readonly-copilot-sdk-ref-impl-version-from-lastmerge-file-updated-by-weekly-reference-impl-sync` .

## `pom.xml` (+70 / -0)

Four additions that together make `pom.xml` the single source of truth for the Copilot CLI version and make `mvn clean verify` self-contained:

1. **New property `<readonly-copilot-sdk-ref-impl-version-from-lastmerge-file-updated-by-weekly-reference-impl-sync>`** = `^1.0.36-0`. Mirrors `dependencies."@github/copilot"` in the cloned reference impl's `nodejs/package.json`. Long doc-comment marks it auto-managed (by the new sync script) and warns against manual edits.
2. **New property `<copilot.cli.path>`** = `${copilot.sdk.clone.dir}/nodejs/node_modules/@github/copilot/index.js`. Doc-comment shows the override syntax (`-Dcopilot.cli.path=...`).
3. **New `exec-maven-plugin` execution `install-nodejs-cli-dependencies`** bound to `generate-test-resources`. Runs `npm ci --ignore-scripts` in `${copilot.sdk.clone.dir}/nodejs/`, honors `${skip.test.harness}`. Re-creates `target/copilot-sdk/nodejs/node_modules` after `clean` wipes it.
4. **`maven-surefire-plugin` configuration** gains `<environmentVariables><COPILOT_CLI_PATH>${copilot.cli.path}</…></…>`, so the forked test JVM uses the pinned CLI with no manual env-var export.

---

## `.github/actions/setup-copilot/action.yml` (+24 / -1)

Replaces the unpinned `npm install -g @github/copilot` with a two-step pinned install:

1. New step **`Read pinned @github/copilot version from pom.xml`** (id: `cli-version`) extracts the pinned version with `sed`. Fails fast if the property is unset or still the `PRIMER_TO_REPLACE` placeholder.
2. **`Install Copilot CLI (pinned to pom.xml version)`** runs `npm install -g "@github/copilot@${CLI_VERSION}"`.

Adds new action output `cli-version` exposing the resolved version.

---

## `.github/scripts/reference-impl-sync/sync-cli-version-from-reference-impl.sh` (new, +80)

New script that keeps the pinned CLI version in `pom.xml` in lockstep with the reference impl pinned in `.lastmerge`:

- Reads `dependencies."@github/copilot"` from the reference impl's `nodejs/package.json` via `node`.
- Locates the repo root by walking up from the script's own location until it finds a `pom.xml` — resilient to relocation, works from any CWD.
- Rewrites the `<readonly-…>` property in `pom.xml` in place using portable `sed`.
- Validates the property exists and a version was extractable; fails fast otherwise.
- Usage: takes the reference-impl directory as `$1` or via `REFERENCE_IMPL_DIR` env var.

---

## `.github/scripts/reference-impl-sync/merge-reference-impl-finish.sh` (+12 / -2)

Wires the new sync script into the reference-impl merge flow:

- After writing `.lastmerge`, invokes `sync-cli-version-from-reference-impl.sh` against the cloned reference impl directory.
- Stages `pom.xml` alongside `.lastmerge` in the same commit so the two values always move together.
- Updated header comment to reflect the new step (the numbered flow is now 5 steps instead of 4).

---

## `CONTRIBUTING.md` (+18 / -2 net)

Reworks the "Running tests and linters" section:

- Renamed to **"Running locally, including tests and linters"**.
- Removed the suggestion to run `mvn generate-test-resources` + `npm ci` + manual `COPILOT_CLI_PATH` export — `pom.xml` now handles all of that automatically.
- Replaced with a single sentence: the POM ensures a known-correct CLI installation; contributors can override with the `copilot.cli.path` Maven property.
- Added a new section **"Running the known correct Copilot CLI installation"** with self-contained POSIX and PowerShell snippets that locate `COPILOT_CLI_PATH` (scoped to `*/nodejs/node_modules/...` so the older harness copy under `target/copilot-sdk/test/harness/node_modules/` can never be selected) and invoke it via `node`.

---

## `.gitignore` (+1)

Minor housekeeping: added `*.sln` (Visual Studio solution files generated when the workspace is opened in VS).
