### PR TITLE
Unify @github/copilot version tracking and rename sync workflow

### DIFF
--- a/.github/actions/setup-copilot/action.yml
+++ b/.github/actions/setup-copilot/action.yml
@@ -21,7 +21,7 @@ runs:
       # implementation pinned in .lastmerge by
       # .github/scripts/reference-impl-sync/sync-cli-version-from-reference-impl.sh.
       run: |
-        PROP="readonly-copilot-sdk-ref-impl-version-from-lastmerge-file-updated-by-weekly-reference-impl-sync"
+        PROP="readonly-copilot-sdk-ref-impl-version-from-lastmerge-file-updated-by-reference-impl-sync"
         VERSION=$(sed -n "s|.*<${PROP}>\(.*\)</${PROP}>.*|\1|p" pom.xml | head -n 1 | tr -d '[:space:]')
         if [[ -z "$VERSION" || "$VERSION" == "PRIMER_TO_REPLACE" ]]; then
           echo "::error::Could not read pinned @github/copilot version from pom.xml property <${PROP}>" >&2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/scripts/codegen"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 1
-    allow:
-      - dependency-name: "@github/copilot"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/prompts/coding-agent-merge-reference-impl-instructions.md
+++ b/.github/prompts/coding-agent-merge-reference-impl-instructions.md
@@ -1,5 +1,5 @@
-<!-- Custom instructions for the Copilot coding agent when triggered by the weekly reference implementation sync workflow. -->
-<!-- This file is read by .github/workflows/weekly-reference-impl-sync.yml and passed as custom_instructions. -->
+<!-- Custom instructions for the Copilot coding agent when triggered by the reference implementation sync workflow. -->
+<!-- This file is read by .github/workflows/reference-impl-sync.yml and passed as custom_instructions. -->
 
 Follow the agentic-merge-reference-impl prompt at .github/prompts/agentic-merge-reference-impl.prompt.md
 to port reference implementation changes to the Java SDK.

--- a/.github/scripts/reference-impl-sync/merge-reference-impl-finish.sh
+++ b/.github/scripts/reference-impl-sync/merge-reference-impl-finish.sh
@@ -67,7 +67,7 @@ echo "▸ Syncing @github/copilot version in scripts/codegen/package.json…"
 "$ROOT_DIR/.github/scripts/reference-impl-sync/sync-codegen-version.sh" "$REFERENCE_IMPL_DIR"
 
 git add .lastmerge pom.xml scripts/codegen/package.json scripts/codegen/package-lock.json
-git commit -m "Update .lastmerge to $NEW_COMMIT and sync pom.xml CLI version"
+git commit -m "Update .lastmerge to $NEW_COMMIT, sync pom.xml CLI version, and update scripts/codegen @github/copilot version"
 
 # ── 3. Push branch ───────────────────────────────────────────
 echo "▸ Pushing branch $BRANCH_NAME to origin…"

--- a/.github/scripts/reference-impl-sync/merge-reference-impl-finish.sh
+++ b/.github/scripts/reference-impl-sync/merge-reference-impl-finish.sh
@@ -7,8 +7,10 @@
 #   2. Updates .lastmerge to reference implementation HEAD
 #   3. Syncs the @github/copilot version property in pom.xml from the
 #      cloned reference implementation's nodejs/package.json
-#   4. Commits the .lastmerge + pom.xml updates
-#   5. Pushes the branch to origin
+#   4. Syncs scripts/codegen/package.json to the same @github/copilot
+#      version so the code generator uses matching schemas
+#   5. Commits the .lastmerge + pom.xml + codegen package updates
+#   6. Pushes the branch to origin
 #
 # Usage:  ./.github/scripts/reference-impl-sync/merge-reference-impl-finish.sh
 #         ./.github/scripts/reference-impl-sync/merge-reference-impl-finish.sh --skip-tests
@@ -56,7 +58,15 @@ echo "$NEW_COMMIT" > "$ROOT_DIR/.lastmerge"
 echo "▸ Syncing @github/copilot version in pom.xml from reference implementation…"
 "$ROOT_DIR/.github/scripts/reference-impl-sync/sync-cli-version-from-reference-impl.sh" "$REFERENCE_IMPL_DIR"
 
-git add .lastmerge pom.xml
+# ── 2c. Sync scripts/codegen @github/copilot version ─────────
+# Keeps scripts/codegen/package.json in lockstep so the code generator
+# uses schemas from the same CLI version that the tests run against.
+# This eliminates the gap where Dependabot could race ahead of the
+# reference implementation sync.
+echo "▸ Syncing @github/copilot version in scripts/codegen/package.json…"
+"$ROOT_DIR/.github/scripts/reference-impl-sync/sync-codegen-version.sh" "$REFERENCE_IMPL_DIR"
+
+git add .lastmerge pom.xml scripts/codegen/package.json scripts/codegen/package-lock.json
 git commit -m "Update .lastmerge to $NEW_COMMIT and sync pom.xml CLI version"
 
 # ── 3. Push branch ───────────────────────────────────────────

--- a/.github/scripts/reference-impl-sync/sync-codegen-version.sh
+++ b/.github/scripts/reference-impl-sync/sync-codegen-version.sh
@@ -1,31 +1,21 @@
 #!/usr/bin/env bash
 # ──────────────────────────────────────────────────────────────
-# sync-cli-version-from-reference-impl.sh
+# sync-codegen-version.sh
 #
-# Reads the @github/copilot version specifier from the cloned
-# reference implementation's nodejs/package.json, and updates the
-# corresponding property in pom.xml:
-#
-#   <readonly-copilot-sdk-ref-impl-version-from-lastmerge-file-updated-by-reference-impl-sync>
-#
-# This keeps the canonical Copilot CLI version (declared in pom.xml)
-# in sync with whatever the reference implementation pinned in
-# .lastmerge depends on. All workflows that install the Copilot CLI
-# (build-test.yml — implicitly via cloned SDK, run-smoke-test.yml and
-# update-copilot-dependency.yml — via the setup-copilot action) read
-# this single property so every CI path uses the same CLI version.
+# Updates the @github/copilot dependency in scripts/codegen/package.json
+# to match the version used by the reference implementation. This keeps
+# the code generator schemas in lockstep with the CLI version used for
+# testing, eliminating the gap where Dependabot could race ahead.
 #
 # Usage:
-#   ./sync-cli-version-from-reference-impl.sh <reference-impl-dir>
+#   ./sync-codegen-version.sh <reference-impl-dir>
 #
-# Or, when invoked from merge-reference-impl-finish.sh, sources
-# REFERENCE_IMPL_DIR from the .merge-env file.
+# Or, when invoked from merge-reference-impl-finish.sh, the directory
+# is passed as $1.
 # ──────────────────────────────────────────────────────────────
 set -euo pipefail
 
 # Locate the repo root by walking up from this script until we find a pom.xml.
-# This is resilient to the script being moved to a different depth under
-# .github/scripts/ in the future.
 find_repo_root() {
     local dir
     dir="$(cd "$(dirname "$0")" && pwd)"
@@ -54,7 +44,7 @@ if [[ ! -f "$PKG_JSON" ]]; then
     exit 1
 fi
 
-# node is always available since the reference implementation uses npm.
+# Extract the @github/copilot version from the reference implementation.
 CLI_VERSION=$(node -e \
     "const fs=require('fs');const p=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const v=(p.dependencies&&p.dependencies['@github/copilot'])||(p.devDependencies&&p.devDependencies['@github/copilot']);process.stdout.write(v||'');" \
     "$PKG_JSON")
@@ -64,17 +54,16 @@ if [[ -z "$CLI_VERSION" ]]; then
     exit 1
 fi
 
-POM="$ROOT_DIR/pom.xml"
-PROP="readonly-copilot-sdk-ref-impl-version-from-lastmerge-file-updated-by-reference-impl-sync"
+CODEGEN_DIR="$ROOT_DIR/scripts/codegen"
+CODEGEN_PKG="$CODEGEN_DIR/package.json"
 
-if ! grep -q "<${PROP}>" "$POM"; then
-    echo "❌ Property <${PROP}> not found in $POM" >&2
+if [[ ! -f "$CODEGEN_PKG" ]]; then
+    echo "❌ Cannot find $CODEGEN_PKG" >&2
     exit 1
 fi
 
-# Use a portable sed invocation (works on both BSD/macOS and GNU/Linux).
-TMP="$(mktemp)"
-sed -E "s|<${PROP}>[^<]*</${PROP}>|<${PROP}>${CLI_VERSION}</${PROP}>|" "$POM" > "$TMP"
-mv "$TMP" "$POM"
-
-echo "▸ Updated pom.xml: <${PROP}> = ${CLI_VERSION}"
+# Update scripts/codegen/package.json with the new version and regenerate the lock file.
+echo "▸ Updating scripts/codegen/package.json: @github/copilot → ${CLI_VERSION}"
+cd "$CODEGEN_DIR"
+npm install "@github/copilot@${CLI_VERSION}" --save-exact
+echo "▸ Updated scripts/codegen to @github/copilot@${CLI_VERSION}"

--- a/.github/scripts/reference-impl-sync/sync-codegen-version.sh
+++ b/.github/scripts/reference-impl-sync/sync-codegen-version.sh
@@ -63,7 +63,9 @@ if [[ ! -f "$CODEGEN_PKG" ]]; then
 fi
 
 # Update scripts/codegen/package.json with the new version and regenerate the lock file.
+# Intentionally omit --save-exact to preserve the version specifier used by the reference
+# implementation (e.g. a caret range like '^1.0.36-0' rather than an exact pin '1.0.36-0').
 echo "▸ Updating scripts/codegen/package.json: @github/copilot → ${CLI_VERSION}"
 cd "$CODEGEN_DIR"
-npm install "@github/copilot@${CLI_VERSION}" --save-exact
+npm install "@github/copilot@${CLI_VERSION}"
 echo "▸ Updated scripts/codegen to @github/copilot@${CLI_VERSION}"

--- a/.github/workflows/reference-impl-sync.lock.yml
+++ b/.github/workflows/reference-impl-sync.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"54f733578d3011b148c7aff09a0e72085d787a777a996488f08aeffdf52ec93b","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"a8ddc201288fc1ba88939597b9aa40e621fb37e1d792c77ffe15fc2eb05f7d8b","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_AGENT_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -22,7 +22,7 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Weekly reference implementation sync workflow. Checks for new commits in the official
+# Reference implementation sync workflow. Checks for new commits in the official
 # Copilot SDK (github/copilot-sdk) and assigns to Copilot to port changes.
 #
 # Secrets used:
@@ -47,11 +47,11 @@
 #   - ghcr.io/github/github-mcp-server:v0.32.0
 #   - node:lts-alpine
 
-name: "Weekly Reference Implementation Sync"
+name: "Reference Implementation Sync"
 "on":
   schedule:
-  - cron: "40 11 * * 0"
-    # Friendly format: weekly (scattered)
+  - cron: "47 22 * * *"
+    # Friendly format: daily (scattered)
   workflow_dispatch:
     inputs:
       aw_context:
@@ -65,7 +65,7 @@ permissions: {}
 concurrency:
   group: "gh-aw-${{ github.workflow }}"
 
-run-name: "Weekly Reference Implementation Sync"
+run-name: "Reference Implementation Sync"
 
 jobs:
   activation:
@@ -97,7 +97,7 @@ jobs:
           GH_AW_INFO_VERSION: "1.0.21"
           GH_AW_INFO_AGENT_VERSION: "1.0.21"
           GH_AW_INFO_CLI_VERSION: "v0.68.3"
-          GH_AW_INFO_WORKFLOW_NAME: "Weekly Reference Implementation Sync"
+          GH_AW_INFO_WORKFLOW_NAME: "Reference Implementation Sync"
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
@@ -132,7 +132,7 @@ jobs:
         id: check-lock-file
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
-          GH_AW_WORKFLOW_FILE: "weekly-reference-impl-sync.lock.yml"
+          GH_AW_WORKFLOW_FILE: "reference-impl-sync.lock.yml"
           GH_AW_CONTEXT_WORKFLOW_REF: "${{ github.workflow_ref }}"
         with:
           script: |
@@ -166,14 +166,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_9a049ffd9b204d97_EOF'
+          cat << 'GH_AW_PROMPT_2d4759ef7bb36ee4_EOF'
           <system>
-          GH_AW_PROMPT_9a049ffd9b204d97_EOF
+          GH_AW_PROMPT_2d4759ef7bb36ee4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9a049ffd9b204d97_EOF'
+          cat << 'GH_AW_PROMPT_2d4759ef7bb36ee4_EOF'
           <safe-output-tools>
           Tools: add_comment(max:10), create_issue, close_issue(max:10), assign_to_agent, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -205,12 +205,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_9a049ffd9b204d97_EOF
+          GH_AW_PROMPT_2d4759ef7bb36ee4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9a049ffd9b204d97_EOF'
+          cat << 'GH_AW_PROMPT_2d4759ef7bb36ee4_EOF'
           </system>
-          {{#runtime-import .github/workflows/weekly-reference-impl-sync.md}}
-          GH_AW_PROMPT_9a049ffd9b204d97_EOF
+          {{#runtime-import .github/workflows/reference-impl-sync.md}}
+          GH_AW_PROMPT_2d4759ef7bb36ee4_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -292,7 +292,7 @@ jobs:
       GH_AW_ASSETS_BRANCH: ""
       GH_AW_ASSETS_MAX_SIZE_KB: 0
       GH_AW_MCP_LOG_DIR: /tmp/gh-aw/mcp-logs/safeoutputs
-      GH_AW_WORKFLOW_ID_SANITIZED: weeklyreferenceimplsync
+      GH_AW_WORKFLOW_ID_SANITIZED: referenceimplsync
     outputs:
       agentic_engine_timeout: ${{ steps.detect-copilot-errors.outputs.agentic_engine_timeout || 'false' }}
       checkout_pr_success: ${{ steps.checkout-pr.outputs.checkout_pr_success || 'true' }}
@@ -381,9 +381,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_2a317c5680ea1925_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_9200497037e2c4bb_EOF'
           {"add_comment":{"max":10,"target":"*"},"assign_to_agent":{"max":1,"model":"claude-opus-4.6","name":"copilot","target":"*"},"close_issue":{"max":10,"required_labels":["reference-impl-sync"],"target":"*"},"create_issue":{"assignees":["copilot-swe-agent"],"expires":144,"labels":["reference-impl-sync"],"max":1,"title_prefix":"[reference-impl-sync] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_2a317c5680ea1925_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_9200497037e2c4bb_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -646,7 +646,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_ee30822602a32ffa_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_c776579ac1ab0d20_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -687,7 +687,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_ee30822602a32ffa_EOF
+          GH_AW_MCP_CONFIG_c776579ac1ab0d20_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -891,7 +891,7 @@ jobs:
       issues: write
       pull-requests: write
     concurrency:
-      group: "gh-aw-conclusion-weekly-reference-impl-sync"
+      group: "gh-aw-conclusion-reference-impl-sync"
       cancel-in-progress: false
     outputs:
       incomplete_count: ${{ steps.report_incomplete.outputs.incomplete_count }}
@@ -926,7 +926,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: "1"
-          GH_AW_WORKFLOW_NAME: "Weekly Reference Implementation Sync"
+          GH_AW_WORKFLOW_NAME: "Reference Implementation Sync"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_REPORT_AS_ISSUE: "false"
@@ -942,7 +942,7 @@ jobs:
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Weekly Reference Implementation Sync"
+          GH_AW_WORKFLOW_NAME: "Reference Implementation Sync"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_DETECTION_CONCLUSION: ${{ needs.detection.outputs.detection_conclusion }}
           GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
@@ -959,7 +959,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_MISSING_TOOL_CREATE_ISSUE: "true"
-          GH_AW_WORKFLOW_NAME: "Weekly Reference Implementation Sync"
+          GH_AW_WORKFLOW_NAME: "Reference Implementation Sync"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -973,7 +973,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_REPORT_INCOMPLETE_CREATE_ISSUE: "true"
-          GH_AW_WORKFLOW_NAME: "Weekly Reference Implementation Sync"
+          GH_AW_WORKFLOW_NAME: "Reference Implementation Sync"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -987,10 +987,10 @@ jobs:
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Weekly Reference Implementation Sync"
+          GH_AW_WORKFLOW_NAME: "Reference Implementation Sync"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
-          GH_AW_WORKFLOW_ID: "weekly-reference-impl-sync"
+          GH_AW_WORKFLOW_ID: "reference-impl-sync"
           GH_AW_ENGINE_ID: "copilot"
           GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
@@ -1098,8 +1098,8 @@ jobs:
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
-          WORKFLOW_NAME: "Weekly Reference Implementation Sync"
-          WORKFLOW_DESCRIPTION: "Weekly reference implementation sync workflow. Checks for new commits in the official\nCopilot SDK (github/copilot-sdk) and assigns to Copilot to port changes."
+          WORKFLOW_NAME: "Reference Implementation Sync"
+          WORKFLOW_DESCRIPTION: "Reference implementation sync workflow. Checks for new commits in the official\nCopilot SDK (github/copilot-sdk) and assigns to Copilot to port changes."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1184,14 +1184,14 @@ jobs:
       pull-requests: write
     timeout-minutes: 15
     env:
-      GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/weekly-reference-impl-sync"
+      GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/reference-impl-sync"
       GH_AW_DETECTION_CONCLUSION: ${{ needs.detection.outputs.detection_conclusion }}
       GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_ENGINE_MODEL: ${{ needs.agent.outputs.model }}
-      GH_AW_WORKFLOW_ID: "weekly-reference-impl-sync"
-      GH_AW_WORKFLOW_NAME: "Weekly Reference Implementation Sync"
+      GH_AW_WORKFLOW_ID: "reference-impl-sync"
+      GH_AW_WORKFLOW_NAME: "Reference Implementation Sync"
     outputs:
       assign_to_agent_assigned: ${{ steps.process_safe_outputs.outputs.assign_to_agent_assigned }}
       assign_to_agent_assignment_error_count: ${{ steps.process_safe_outputs.outputs.assign_to_agent_assignment_error_count }}

--- a/.github/workflows/reference-impl-sync.md
+++ b/.github/workflows/reference-impl-sync.md
@@ -1,10 +1,10 @@
 ---
 description: |
-  Weekly reference implementation sync workflow. Checks for new commits in the official
+  Reference implementation sync workflow. Checks for new commits in the official
   Copilot SDK (github/copilot-sdk) and assigns to Copilot to port changes.
 
 on:
-  schedule: weekly
+  schedule: daily
   workflow_dispatch:
 
 permissions:
@@ -41,7 +41,7 @@ safe-outputs:
   noop:
     report-as-issue: false
 ---
-# Weekly Reference Implementation Sync
+# Reference Implementation Sync
 
 You are an automation agent that detects new reference implementation changes and creates GitHub issues. You do **NOT** perform any code merges, edits, or pushes. Do **NOT** invoke any skills (especially `agentic-merge-reference-impl`). Your only job is to check for changes and use safe-output tools to create or close issues.
 

--- a/.github/workflows/reference-impl-sync.yml
+++ b/.github/workflows/reference-impl-sync.yml
@@ -2,8 +2,8 @@ name: "Reference Implementation Sync"
 
 on:
   schedule:
-    # Daily at 10:00 UTC (5:00 AM EST / 6:00 AM EDT)
-    - cron: '0 10 * * *'
+    # Tuesday and Thursday at 10:00 UTC (5:00 AM EST / 6:00 AM EDT)
+    - cron: '0 10 * * 2,4'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/reference-impl-sync.yml
+++ b/.github/workflows/reference-impl-sync.yml
@@ -1,9 +1,9 @@
-name: "Weekly Reference Implementation Sync"
+name: "Reference Implementation Sync"
 
 on:
   schedule:
-    # Every Monday at 10:00 UTC (5:00 AM EST / 6:00 AM EDT)
-    - cron: '0 10 * * 1'
+    # Daily at 10:00 UTC (5:00 AM EST / 6:00 AM EDT)
+    - cron: '0 10 * * *'
   workflow_dispatch:
 
 permissions:
@@ -152,7 +152,7 @@ jobs:
           ISSUE_URL="${{ steps.create-issue.outputs.issue_url }}"
 
           {
-            echo "## Weekly Reference Implementation Sync"
+            echo "## Reference Implementation Sync"
             echo ""
             if [ "$HAS_CHANGES" = "true" ]; then
               echo "### ✅ New reference implementation changes detected"

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Contributions are welcome! Please see the [Contributing Guide](CONTRIBUTING.md) 
 
 This SDK tracks the official [Copilot SDK](https://github.com/github/copilot-sdk) (.NET reference implementation) and ports changes to Java. The reference implementation merge process is automated with AI assistance:
 
-**Daily automated sync** — A [scheduled GitHub Actions workflow](.github/workflows/reference-impl-sync.yml) runs daily at 10:00 UTC. It checks for new reference implementation commits since the last merge (tracked in [`.lastmerge`](.lastmerge)), and if changes are found, creates an issue labeled `reference-impl-sync` and assigns it to the GitHub Copilot coding agent. Any previously open `reference-impl-sync` issues are automatically closed. The sync also updates the `@github/copilot` version in both `pom.xml` and `scripts/codegen/package.json` to keep schemas and test CLI in lockstep.
+**Automated sync** — A [scheduled GitHub Actions workflow](.github/workflows/reference-impl-sync.yml) runs on the schedule specified in that file. It checks for new reference implementation commits since the last merge (tracked in [`.lastmerge`](.lastmerge)), and if changes are found, creates an issue labeled `reference-impl-sync` and assigns it to the GitHub Copilot coding agent. Any previously open `reference-impl-sync` issues are automatically closed. The sync also updates the `@github/copilot` version in both `pom.xml` and `scripts/codegen/package.json` to keep schemas and test CLI in lockstep.
 
 **Reusable prompt** — The merge workflow is defined in [`agentic-merge-reference-impl.prompt.md`](.github/prompts/agentic-merge-reference-impl.prompt.md). It can be triggered manually from:
 - **VS Code Copilot Chat** — type `/agentic-merge-reference-impl`

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Contributions are welcome! Please see the [Contributing Guide](CONTRIBUTING.md) 
 
 This SDK tracks the official [Copilot SDK](https://github.com/github/copilot-sdk) (.NET reference implementation) and ports changes to Java. The reference implementation merge process is automated with AI assistance:
 
-**Weekly automated sync** — A [scheduled GitHub Actions workflow](.github/workflows/weekly-reference-impl-sync.yml) runs every Monday at 5 AM ET. It checks for new reference implementation commits since the last merge (tracked in [`.lastmerge`](.lastmerge)), and if changes are found, creates an issue labeled `reference-impl-sync` and assigns it to the GitHub Copilot coding agent. Any previously open `reference-impl-sync` issues are automatically closed.
+**Daily automated sync** — A [scheduled GitHub Actions workflow](.github/workflows/reference-impl-sync.yml) runs daily at 10:00 UTC. It checks for new reference implementation commits since the last merge (tracked in [`.lastmerge`](.lastmerge)), and if changes are found, creates an issue labeled `reference-impl-sync` and assigns it to the GitHub Copilot coding agent. Any previously open `reference-impl-sync` issues are automatically closed. The sync also updates the `@github/copilot` version in both `pom.xml` and `scripts/codegen/package.json` to keep schemas and test CLI in lockstep.
 
 **Reusable prompt** — The merge workflow is defined in [`agentic-merge-reference-impl.prompt.md`](.github/prompts/agentic-merge-reference-impl.prompt.md). It can be triggered manually from:
 - **VS Code Copilot Chat** — type `/agentic-merge-reference-impl`

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -9,8 +9,8 @@
 | [Update @github/copilot Dependency](workflows/update-copilot-dependency.yml) | Updates the `@github/copilot` npm package, re-runs code generation, and opens a PR | `workflow_dispatch` | — |
 | [Deploy Documentation](workflows/deploy-site.yml) | Generates and deploys versioned docs to GitHub Pages | `workflow_run` (after Build & Test), `release`, `workflow_dispatch` | — |
 | [Publish to Maven Central](workflows/publish-maven.yml) | Releases the SDK to Maven Central and creates a GitHub Release | `workflow_dispatch` | — |
-| [Reference Implementation Sync](workflows/reference-impl-sync.yml) | Checks for new reference implementation commits and creates an issue for Copilot to merge | `workflow_dispatch` | Daily at 10:00 UTC |
-| [Reference Implementation Sync (Agentic)](workflows/reference-impl-sync.lock.yml) | Compiled agentic workflow that executes the reference implementation sync via `gh-aw` | `workflow_dispatch` | Daily (scattered) |
+| [Reference Implementation Sync](workflows/reference-impl-sync.yml) | Checks for new reference implementation commits and creates an issue for Copilot to merge | `workflow_dispatch` | [See workflow](workflows/reference-impl-sync.yml) |
+| [Reference Implementation Sync (Agentic)](workflows/reference-impl-sync.lock.yml) | Compiled agentic workflow that executes the reference implementation sync via `gh-aw` | `workflow_dispatch` | [See workflow](workflows/reference-impl-sync.yml) |
 | [Copilot Setup Steps](workflows/copilot-setup-steps.yml) | Configures the environment for the GitHub Copilot coding agent | `push` (on self-change), `workflow_dispatch` | — |
 
 ---
@@ -68,7 +68,7 @@ Manual-only workflow that performs a full release:
 
 **File:** [`reference-impl-sync.yml`](workflows/reference-impl-sync.yml)
 
-Runs daily at 10:00 UTC. Clones the official `github/copilot-sdk` repository and compares `HEAD` against the commit hash stored in `.lastmerge`.
+Runs on the schedule specified in [`.github/workflows/reference-impl-sync.yml`](workflows/reference-impl-sync.yml). Clones the official `github/copilot-sdk` repository and compares `HEAD` against the commit hash stored in `.lastmerge`.
 
 If new commits are found:
 1. Closes any previously open `reference-impl-sync` issues

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -6,11 +6,11 @@
 |----------|-------------|----------|----------|
 | [Build & Test](workflows/build-test.yml) | Builds, lints, and tests the Java SDK | `push` (main), `pull_request`, `merge_group`, `workflow_dispatch` | Sundays at 00:00 UTC |
 | [Codegen Check](workflows/codegen-check.yml) | Verifies that generated Java files are up-to-date with the JSON schemas | `push` (main), `pull_request`, `workflow_dispatch` | — |
-| [Update @github/copilot Dependency](workflows/update-copilot-dependency.yml) | Updates the `@github/copilot` npm package, re-runs code generation, and opens a PR | `workflow_dispatch` | — |
+| [Update @github/copilot Dependency](workflows/update-copilot-dependency.yml) | _(Codegen-only)_ Updates the `@github/copilot` npm package in `scripts/codegen`, re-runs code generation, and opens a PR. Does **not** update `pom.xml`; use the Reference Implementation Sync for full version alignment. | `workflow_dispatch` | — |
 | [Deploy Documentation](workflows/deploy-site.yml) | Generates and deploys versioned docs to GitHub Pages | `workflow_run` (after Build & Test), `release`, `workflow_dispatch` | — |
 | [Publish to Maven Central](workflows/publish-maven.yml) | Releases the SDK to Maven Central and creates a GitHub Release | `workflow_dispatch` | — |
 | [Reference Implementation Sync](workflows/reference-impl-sync.yml) | Checks for new reference implementation commits and creates an issue for Copilot to merge | `workflow_dispatch` | [See workflow](workflows/reference-impl-sync.yml) |
-| [Reference Implementation Sync (Agentic)](workflows/reference-impl-sync.lock.yml) | Compiled agentic workflow that executes the reference implementation sync via `gh-aw` | `workflow_dispatch` | [See workflow](workflows/reference-impl-sync.yml) |
+| [Reference Implementation Sync (Agentic)](workflows/reference-impl-sync.lock.yml) | Compiled agentic workflow that executes the reference implementation sync via `gh-aw` | `workflow_dispatch` | [See workflow](workflows/reference-impl-sync.lock.yml) |
 | [Copilot Setup Steps](workflows/copilot-setup-steps.yml) | Configures the environment for the GitHub Copilot coding agent | `push` (on self-change), `workflow_dispatch` | — |
 
 ---
@@ -112,6 +112,8 @@ If changes appear, commit the updated generated files.
 ## Update @github/copilot Dependency
 
 **File:** [`update-copilot-dependency.yml`](workflows/update-copilot-dependency.yml)
+
+> **Note:** This workflow is for codegen-only updates to `scripts/codegen`. It does **not** update `pom.xml`. For full version alignment (both CLI and codegen in lockstep), use the **Reference Implementation Sync** workflow instead.
 
 Manual workflow triggered when a new version of the `@github/copilot` npm package is published. Accepts a `version` input (e.g. `1.0.25`).
 

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -9,8 +9,8 @@
 | [Update @github/copilot Dependency](workflows/update-copilot-dependency.yml) | Updates the `@github/copilot` npm package, re-runs code generation, and opens a PR | `workflow_dispatch` | — |
 | [Deploy Documentation](workflows/deploy-site.yml) | Generates and deploys versioned docs to GitHub Pages | `workflow_run` (after Build & Test), `release`, `workflow_dispatch` | — |
 | [Publish to Maven Central](workflows/publish-maven.yml) | Releases the SDK to Maven Central and creates a GitHub Release | `workflow_dispatch` | — |
-| [Weekly Reference Implementation Sync](workflows/weekly-reference-impl-sync.yml) | Checks for new reference implementation commits and creates an issue for Copilot to merge | `workflow_dispatch` | Mondays at 10:00 UTC |
-| [Weekly Reference Implementation Sync (Agentic)](workflows/weekly-reference-impl-sync.lock.yml) | Compiled agentic workflow that executes the reference implementation sync via `gh-aw` | `workflow_dispatch` | Tuesdays at 08:39 UTC (scattered) |
+| [Reference Implementation Sync](workflows/reference-impl-sync.yml) | Checks for new reference implementation commits and creates an issue for Copilot to merge | `workflow_dispatch` | Daily at 10:00 UTC |
+| [Reference Implementation Sync (Agentic)](workflows/reference-impl-sync.lock.yml) | Compiled agentic workflow that executes the reference implementation sync via `gh-aw` | `workflow_dispatch` | Daily (scattered) |
 | [Copilot Setup Steps](workflows/copilot-setup-steps.yml) | Configures the environment for the GitHub Copilot coding agent | `push` (on self-change), `workflow_dispatch` | — |
 
 ---
@@ -64,11 +64,11 @@ Manual-only workflow that performs a full release:
 
 ---
 
-## Weekly Reference Implementation Sync
+## Reference Implementation Sync
 
-**File:** [`weekly-reference-impl-sync.yml`](workflows/weekly-reference-impl-sync.yml)
+**File:** [`reference-impl-sync.yml`](workflows/reference-impl-sync.yml)
 
-Runs every Monday at 10:00 UTC. Clones the official `github/copilot-sdk` repository and compares `HEAD` against the commit hash stored in `.lastmerge`.
+Runs daily at 10:00 UTC. Clones the official `github/copilot-sdk` repository and compares `HEAD` against the commit hash stored in `.lastmerge`.
 
 If new commits are found:
 1. Closes any previously open `reference-impl-sync` issues
@@ -79,9 +79,9 @@ If no changes are found, any stale open `reference-impl-sync` issues are closed.
 
 ---
 
-## Weekly Reference Implementation Sync (Agentic Workflow: Experimental)
+## Reference Implementation Sync (Agentic Workflow: Experimental)
 
-**File:** [`weekly-reference-impl-sync.lock.yml`](workflows/weekly-reference-impl-sync.lock.yml)
+**File:** [`reference-impl-sync.lock.yml`](workflows/reference-impl-sync.lock.yml)
 
 Auto-generated compiled workflow produced by `gh aw compile` from the corresponding `.md` source. This is the agentic counterpart that actually executes the reference implementation merge using the `gh-aw` MCP server and Copilot coding agent.
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
             reference-impl-sync workflow and deal with the subsequent
             PR.
         -->
-        <readonly-copilot-sdk-ref-impl-version-from-lastmerge-file-updated-by-weekly-reference-impl-sync>^1.0.36-0</readonly-copilot-sdk-ref-impl-version-from-lastmerge-file-updated-by-weekly-reference-impl-sync>
+        <readonly-copilot-sdk-ref-impl-version-from-lastmerge-file-updated-by-reference-impl-sync>^1.0.36-0</readonly-copilot-sdk-ref-impl-version-from-lastmerge-file-updated-by-reference-impl-sync>
 
     </properties>
 

--- a/src/test/java/com/github/copilot/sdk/generated/rpc/GeneratedRpcRecordsCoverageTest.java
+++ b/src/test/java/com/github/copilot/sdk/generated/rpc/GeneratedRpcRecordsCoverageTest.java
@@ -483,21 +483,23 @@ class GeneratedRpcRecordsCoverageTest {
 
     @Test
     void sessionAgentListResult_with_items() {
-        var item = new AgentInfo("name1", "Name One", "Desc 1");
+        var item = new AgentInfo("name1", "Name One", "Desc 1", "/path/to/agent1");
         var result = new SessionAgentListResult(List.of(item));
         assertEquals(1, result.agents().size());
         assertEquals("name1", result.agents().get(0).name());
         assertEquals("Name One", result.agents().get(0).displayName());
         assertEquals("Desc 1", result.agents().get(0).description());
+        assertEquals("/path/to/agent1", result.agents().get(0).path());
     }
 
     @Test
     void sessionAgentGetCurrentResult_nested() {
-        var agent = new AgentInfo("agent-1", "Agent One", "Does things");
+        var agent = new AgentInfo("agent-1", "Agent One", "Does things", null);
         var result = new SessionAgentGetCurrentResult(agent);
         assertEquals("agent-1", result.agent().name());
         assertEquals("Agent One", result.agent().displayName());
         assertEquals("Does things", result.agent().description());
+        assertNull(result.agent().path());
     }
 
     @Test
@@ -508,7 +510,7 @@ class GeneratedRpcRecordsCoverageTest {
 
     @Test
     void sessionAgentReloadResult_with_items() {
-        var item = new AgentInfo("a", "A", "Desc");
+        var item = new AgentInfo("a", "A", "Desc", "/path/to/a");
         var result = new SessionAgentReloadResult(List.of(item));
         assertEquals(1, result.agents().size());
         assertEquals("a", result.agents().get(0).name());
@@ -516,7 +518,7 @@ class GeneratedRpcRecordsCoverageTest {
 
     @Test
     void sessionAgentSelectResult_nested() {
-        var agent = new AgentInfo("selected", "Selected", "The selected agent");
+        var agent = new AgentInfo("selected", "Selected", "The selected agent", "/path/to/selected");
         var result = new SessionAgentSelectResult(agent);
         assertEquals("selected", result.agent().name());
     }


### PR DESCRIPTION
Problem:
Two independent paths updated the @github/copilot dependency:
1. Dependabot bumped scripts/codegen/package.json (for schema codegen)
2. The weekly reference-impl sync updated pom.xml (for CLI test binary)

These could drift apart, causing schema/CLI version mismatches.

Solution (Option C):
Make the reference-impl sync the single entry point for all @github/copilot
version changes. During sync, both pom.xml AND scripts/codegen/package.json
are updated from the reference implementation's nodejs/package.json.

Changes:

1. New script: sync-codegen-version.sh
   - Extracts @github/copilot version from reference impl
   - Runs npm install in scripts/codegen/ to update package.json and lock file

2. Updated merge-reference-impl-finish.sh
   - Calls sync-codegen-version.sh after the existing pom.xml sync
   - Stages scripts/codegen/package.json and package-lock.json in the commit

3. Removed Dependabot npm entry for /scripts/codegen
   - No longer needed since the reference-impl sync handles this dependency

4. Renamed workflow files (removed timing from names):
   - weekly-reference-impl-sync.yml    -> reference-impl-sync.yml
   - weekly-reference-impl-sync.md     -> reference-impl-sync.md
   - weekly-reference-impl-sync.lock.yml -> reference-impl-sync.lock.yml

5. Changed schedule from weekly (Monday) to daily

6. Removed all "weekly"/"Weekly" timing references from:
   - Workflow files (.yml, .md, .lock.yml)
   - POM property name (removed "weekly" from the long property name)
   - setup-copilot/action.yml
   - sync-cli-version-from-reference-impl.sh
   - coding-agent-merge-reference-impl-instructions.md
   - README.md
   - docs/WORKFLOWS.md

7. Recompiled agentic workflow lock file via gh aw compile
