### PR TITLE
Ensure reporting is aware of the two test executions.

### DIFF
--- a/.github/actions/test-report/action.yml
+++ b/.github/actions/test-report/action.yml
@@ -25,8 +25,7 @@ runs:
         REPORT_DIR=$(dirname "${{ inputs.report-path }}")
         REPORT_PATTERN=$(basename "${{ inputs.report-path }}")
 
-        # Use compgen to check if the glob expands to any files
-        if compgen -G "${{ inputs.report-path }}" > /dev/null 2>&1; then
+        if ls ${{ inputs.report-path }} 1>/dev/null 2>&1; then
           TESTS_RUN=$(grep -h "tests=" ${{ inputs.report-path }} 2>/dev/null | sed 's/.*tests="\([0-9]*\)".*/\1/' | awk '{s+=$1} END {print s}')
           FAILURES=$(grep -h "failures=" ${{ inputs.report-path }} 2>/dev/null | sed 's/.*failures="\([0-9]*\)".*/\1/' | awk '{s+=$1} END {print s}')
           ERRORS=$(grep -h "errors=" ${{ inputs.report-path }} 2>/dev/null | sed 's/.*errors="\([0-9]*\)".*/\1/' | awk '{s+=$1} END {print s}')

--- a/.github/actions/test-report/action.yml
+++ b/.github/actions/test-report/action.yml
@@ -4,7 +4,7 @@ inputs:
   report-path:
     description: "Path to the test report XML files (glob pattern)"
     required: false
-    default: "target/surefire-reports/TEST-*.xml"
+    default: "target/surefire-reports*/TEST-*.xml"
   jacoco-path:
     description: "Path to the JaCoCo XML report"
     required: false
@@ -25,7 +25,8 @@ runs:
         REPORT_DIR=$(dirname "${{ inputs.report-path }}")
         REPORT_PATTERN=$(basename "${{ inputs.report-path }}")
 
-        if [ -d "$REPORT_DIR" ]; then
+        # Use compgen to check if the glob expands to any files
+        if compgen -G "${{ inputs.report-path }}" > /dev/null 2>&1; then
           TESTS_RUN=$(grep -h "tests=" ${{ inputs.report-path }} 2>/dev/null | sed 's/.*tests="\([0-9]*\)".*/\1/' | awk '{s+=$1} END {print s}')
           FAILURES=$(grep -h "failures=" ${{ inputs.report-path }} 2>/dev/null | sed 's/.*failures="\([0-9]*\)".*/\1/' | awk '{s+=$1} END {print s}')
           ERRORS=$(grep -h "errors=" ${{ inputs.report-path }} 2>/dev/null | sed 's/.*errors="\([0-9]*\)".*/\1/' | awk '{s+=$1} END {print s}')

--- a/.github/actions/test-report/action.yml
+++ b/.github/actions/test-report/action.yml
@@ -22,9 +22,6 @@ runs:
         echo "## 🧪 Copilot Java SDK :: Test Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
 
-        REPORT_DIR=$(dirname "${{ inputs.report-path }}")
-        REPORT_PATTERN=$(basename "${{ inputs.report-path }}")
-
         if ls ${{ inputs.report-path }} 1>/dev/null 2>&1; then
           TESTS_RUN=$(grep -h "tests=" ${{ inputs.report-path }} 2>/dev/null | sed 's/.*tests="\([0-9]*\)".*/\1/' | awk '{s+=$1} END {print s}')
           FAILURES=$(grep -h "failures=" ${{ inputs.report-path }} 2>/dev/null | sed 's/.*failures="\([0-9]*\)".*/\1/' | awk '{s+=$1} END {print s}')

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -130,6 +130,7 @@ jobs:
           path: |
             target/jacoco-test-results/sdk-tests.exec
             target/surefire-reports/
+            target/surefire-reports-isolated/
           retention-days: 1
 
       - name: Generate JaCoCo badge

--- a/pom.xml
+++ b/pom.xml
@@ -359,6 +359,11 @@
                         </goals>
                         <configuration>
                             <groups>isolated-resume</groups>
+                            <!-- Use a separate report directory so these results
+                                 don't overwrite the default-test XML reports for
+                                 the same test classes (CopilotSessionTest,
+                                 StreamingFidelityTest). -->
+                            <reportsDirectory>${project.build.directory}/surefire-reports-isolated</reportsDirectory>
                         </configuration>
                     </execution>
                     <!-- Exclude the isolated resume tests from the main run -->


### PR DESCRIPTION
1. **action.yml** — Widens the default `report-path` glob from `target/surefire-reports/TEST-*.xml` to `target/surefire-reports*/TEST-*.xml` so both report directories are picked up. Replaces the `-d "$REPORT_DIR"` directory check since the path now contains a wildcard in the directory component.

2. **build-test.yml** — Adds `target/surefire-reports-isolated/` to the artifact upload path so the isolated execution's reports are preserved in CI.

3. **pom.xml** — Adds `<reportsDirectory>${project.build.directory}/surefire-reports-isolated</reportsDirectory>` (with a comment) to the `isolated-resume-tests` Surefire execution so its XML reports don't overwrite the default-test reports for the same classes.
