### PR TITLE
Fix: Ensure dependencies label on PRs before codegen-agentic-fix pushes

### DIFF
--- a/.github/workflows/codegen-check.yml
+++ b/.github/workflows/codegen-check.yml
@@ -128,6 +128,9 @@ jobs:
         run: |
           ERROR_SUMMARY=$(cat /tmp/error-summary.txt)
 
+          # Ensure PR has dependencies label (required by codegen-agentic-fix safe-output)
+          gh pr edit "$PR_NUMBER" --add-label dependencies
+
           gh workflow run codegen-agentic-fix.lock.yml \
             -f branch="$BRANCH" \
             -f pr_number="$PR_NUMBER" \

--- a/.github/workflows/update-copilot-dependency.yml
+++ b/.github/workflows/update-copilot-dependency.yml
@@ -147,6 +147,7 @@ jobs:
           if gh pr view "$BRANCH" >/dev/null 2>&1; then
             echo "Pull request for branch '$BRANCH' already exists; updated branch only."
             PR_NUMBER=$(gh pr view "$BRANCH" --json number --jq .number)
+            gh pr edit "$PR_NUMBER" --add-label dependencies
           else
             PR_NUMBER=$(gh pr create \
               --title "Update @github/copilot to $VERSION" \


### PR DESCRIPTION
Fixes https://github.com/github/copilot-sdk-java/issues/199

The codegen-agentic-fix workflow's push-to-pull-request-branch safe-output requires the target PR to have the `dependencies` label. Two gaps allowed PRs to reach the agentic fix without this label:

1. update-copilot-dependency.yml: When the PR branch already exists from a prior run, the workflow reused it without adding the label. Now calls `gh pr edit --add-label dependencies` in that path.

2. codegen-check.yml: When triggering the agentic fix from any PR that touches codegen paths, the PR might not have the label (e.g., a manual PR or one created before the fix). Now ensures the label is present before dispatching codegen-agentic-fix.lock.yml.