### PR TITLE
Remove MONOREPO_READ_TOKEN validation step — monorepo is public

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -35,26 +35,23 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      # 0. Validate required secrets and inputs
-      - name: Validate inputs and secrets
-        env:
-          MONOREPO_READ_TOKEN: ${{ secrets.MONOREPO_READ_TOKEN }}
+      # 0. Validate inputs
+      - name: Validate inputs
         run: |
-          if [[ -z "${MONOREPO_READ_TOKEN}" ]]; then
-            echo "::error::MONOREPO_READ_TOKEN secret is required but not configured."
-            exit 1
-          fi
           VERSION="${{ inputs.version }}"
-          if [[ "${VERSION}" != java/v* ]]; then
-            echo "::error::VERSION must start with 'java/v' (got: '${VERSION}')"
+          if [[ -z "${VERSION}" ]]; then
+            echo "::error::version input is required"
             exit 1
           fi
           if [[ "${VERSION}" == *"../"* ]]; then
-            echo "::error::VERSION must not contain '../'"
+            echo "::error::version must not contain '../'"
             exit 1
           fi
-          DEPLOY_VERSION="${VERSION#java/v}"
-          echo "DEPLOY_VERSION=${DEPLOY_VERSION}" >> "$GITHUB_ENV"
+          TAG="${{ inputs.monorepo_tag }}"
+          if [[ "${TAG}" != java/v* ]]; then
+            echo "::error::monorepo_tag must start with 'java/v' (got: '${TAG}')"
+            exit 1
+          fi
 
       # 1. Checkout this (standalone) repo — has src/site/, pom.xml, templates
       - name: Checkout standalone repo


### PR DESCRIPTION
Also fix version validation: the 'version' input is a bare version string (e.g. 1.0.0-beta-10-java.5), not a tag. Validate monorepo_tag instead.